### PR TITLE
Add placeholders for editor and reviewers

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -4,3 +4,8 @@ process.
 
 See the [project readme](https://github.com/scipy-conference/scipy_proceedings#build-your-paper)
 for more information.
+
+
+*Editor*: <!--editor--> <!--end-editor-->
+
+*Reviewers*: <!--reviewers-list--> <!--end-reviewers-list-->


### PR DESCRIPTION
This PR adds the missing HTML comments to the PR template for the `assign editor` and `add to reviewers` commands to work.

Re: https://github.com/scipy-conference/buffy/issues/1#issuecomment-847510084

With this change, the add/remove_reviewer_n responders can be [removed from the config](https://github.com/scipy-conference/buffy/blob/scipy/config/settings-production.yml#L26-L32) file. If instead, those responders are prefered for assigning reviewers, then the list_of_values is the one that can be deleted, and the reviewers-list HTML comment in this PR should be changed from:
```html
Reviewers: <!--reviewers-list--> <!--end-reviewers-list-->
```
to:
```html
Reviewer 1: <!--reviewer-1-->  <!--end-reviewer-1-->
Reviewer 2: <!--reviewer-2-->  <!--end-reviewer-2-->
```